### PR TITLE
docs: add repository clone instructions to README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,14 @@ MCP (Model Context Protocol) server for Google Calendar color-based time analysi
 
 ## Installation & Setup
 
-### 1. Prerequisites
+### 1. Clone the Repository
+
+```bash
+git clone https://github.com/talasago/gcal-color-time-tracker-mcp.git
+cd gcal-color-time-tracker-mcp
+```
+
+### 2. Prerequisites
 
 This project requires Ruby and bundler to be installed on your system.
 
@@ -34,25 +41,25 @@ sudo apt-get install ruby-dev
 gem install bundler
 ```
 
-### 2. Install Dependencies
+### 3. Install Dependencies
 
 ```bash
 bundle install
 ```
 
-### 3. Google Cloud Console Setup
+### 4. Google Cloud Console Setup
 
-#### 3.1. Create or Select Project
+#### 4.1. Create or Select Project
 1. Access [Google Cloud Console](https://console.cloud.google.com/)
 2. Create a new project or select an existing project
 3. Confirm the correct project is selected at the top of the console
 
-#### 3.2. Enable Google Calendar API
+#### 4.2. Enable Google Calendar API
 1. Confirm the correct project is selected
 2. Access [Calendar API library page](https://console.cloud.google.com/apis/library/calendar-json.googleapis.com)
 3. Click "Enable"
 
-#### 3.3. Create OAuth 2.0 Credentials
+#### 4.3. Create OAuth 2.0 Credentials
 1. Select "Credentials" from the left menu
 2. Click "Create Credentials" → "OAuth client ID"
 3. Configure OAuth consent screen (first time only):
@@ -67,21 +74,21 @@ bundle install
 5. Enter a name (e.g., Calendar Color MCP)
 6. Click "Create"
 
-#### 3.4. Get Credentials
+#### 4.4. Get Credentials
 1. Copy the "Client ID" and "Client Secret" from the created OAuth client
 2. Configure these settings in the JSON file below
 
-#### 3.5. Add Test Users
+#### 4.5. Add Test Users
 1. Go to OAuth consent screen settings and navigate to "Test users" section
 2. Click "Add users" and add the email address of the Google account that will access the calendar
 3. ⚠️ **Note**: Adding test users may take a few minutes
 
-### 4. Claude Desktop Configuration
+### 5. Claude Desktop Configuration
 
 Configure environment variables in the Claude Desktop configuration file (`claude_desktop_config.json`).
 See the "Claude Desktop Usage Examples" section for configuration details.
 
-### 5. Grant Execution Permissions
+### 6. Grant Execution Permissions
 
 ```bash
 chmod +x bin/calendar-color-mcp

--- a/README_ja.md
+++ b/README_ja.md
@@ -15,7 +15,14 @@ Google Calendar色別時間分析のためのMCP (Model Context Protocol) サー
 
 ## インストール・セットアップ
 
-### 1. 前提条件
+### 1. リポジトリのクローン
+
+```bash
+git clone https://github.com/talasago/gcal-color-time-tracker-mcp.git
+cd gcal-color-time-tracker-mcp
+```
+
+### 2. 前提条件
 
 このプロジェクトを実行するには、RubyとBundlerがシステムにインストールされている必要があります。
 
@@ -34,25 +41,25 @@ sudo apt-get install ruby-dev
 gem install bundler
 ```
 
-### 2. 依存関係のインストール
+### 3. 依存関係のインストール
 
 ```bash
 bundle install
 ```
 
-### 3. Google Cloud Console設定
+### 4. Google Cloud Console設定
 
-#### 3.1. プロジェクトの作成・選択
+#### 4.1. プロジェクトの作成・選択
 1. [Google Cloud Console](https://console.cloud.google.com/)にアクセス
 2. 新規プロジェクトを作成するか、既存プロジェクトを選択
 3. コンソール上部でプロジェクトが正しく選択されていることを確認
 
-#### 3.2. Google Calendar APIの有効化
+#### 4.2. Google Calendar APIの有効化
 1. 正しいプロジェクトが選択されていることを確認
 2. [Calendar API library page](https://console.cloud.google.com/apis/library/calendar-json.googleapis.com)にアクセス
 3. 「有効にする」をクリック
 
-#### 3.3. OAuth 2.0 認証情報の作成
+#### 4.3. OAuth 2.0 認証情報の作成
 1. 左側メニューから「認証情報」を選択
 2. 「認証情報を作成」→「OAuth クライアントID」をクリック
 3. OAuth同意画面の設定（初回のみ）：
@@ -67,21 +74,21 @@ bundle install
 5. 名前を入力（例：Calendar Color MCP）
 6. 「作成」をクリック
 
-#### 3.4. 認証情報の取得
+#### 4.4. 認証情報の取得
 1. 作成されたOAuthクライアントの「クライアントID」と「クライアントシークレット」をコピー
 2. これらの設定を下部のjsonファイルで設定します
 
-#### 3.5. テストユーザーの追加
+#### 4.5. テストユーザーの追加
 1. OAuth同意画面設定で「テストユーザー」セクションに移動
 2. 「ユーザーを追加」をクリックして、カレンダーにアクセスするGoogleアカウントのメールアドレスを追加
 3. ⚠️ **注意**: テストユーザーの追加には数分かかる場合があります
 
-### 4. Claude Desktop設定
+### 5. Claude Desktop設定
 
 Claude Desktop設定ファイル (`claude_desktop_config.json`) で環境変数を設定します。
 設定方法は「Claude Desktop での使用例」セクションを参照してください。
 
-### 5. 実行権限付与
+### 6. 実行権限付与
 
 ```bash
 chmod +x bin/calendar-color-mcp


### PR DESCRIPTION
Added step 1 "Clone the Repository" section to both English and Japanese README files. Updated section numbering from 2-6 to maintain proper sequence.

🤖 Generated with [Claude Code](https://claude.ai/code)